### PR TITLE
Fix empty queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed empty `SELECT` and `WITH` queries.
+
 ## [0.3.0] - 2023-04-09
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fixed empty `SELECT` and `WITH` queries.
+- Fix empty output from queries that should return output.
 
 ## [0.3.0] - 2023-04-09
 

--- a/src/ls/driver.ts
+++ b/src/ls/driver.ts
@@ -56,7 +56,11 @@ export default class ClickHouseDriver
     return this.open().then((ch) => {
       return new Promise<NSDatabase.IResult[]>(async (resolve) => {
         const { requestId } = opt;
-        const method = query.toString().startsWith("SELECT") ? "query" : "exec";
+        const queryStart = query.toString().trimStart().toUpperCase();
+        const method =
+          queryStart.startsWith("SELECT") || queryStart.startsWith("WITH")
+            ? "query"
+            : "exec";
 
         try {
           if (method === "query") {


### PR DESCRIPTION
Query output was shown only when query starts with `SELECT`.
Now it should work with `SELECT` and `WITH` in both upper and lower cases and when query starts with spaces or newlines.

Should fix #377.

![image](https://user-images.githubusercontent.com/42237599/231596081-4859424a-622a-4818-89a6-6dbcc6e1c7fd.png)
