### PR TITLE
Add TLS configuration

### DIFF
--- a/connection.schema.json
+++ b/connection.schema.json
@@ -32,6 +32,31 @@
       "title": "Password",
       "type": "string",
       "default": ""
+    },
+    "tls": {
+      "title": "TLS configuration",
+      "type": "object",
+      "properties": {
+        "ca_cert": {
+          "title": "CA Cert",
+          "type": ["string", "null"],
+          "format": "data-url"
+        },
+        "cert": {
+          "title": "Cert",
+          "type": ["string", "null"],
+          "format": "data-url"
+        },
+        "key": {
+          "title": "Key",
+          "type": ["string", "null"],
+          "format": "data-url"
+        }
+      },
+      "dependencies": {
+        "cert": ["ca_cert", "key"],
+        "key": ["ca_cert", "cert"]
+      }
     }
   },
   "required": ["server"]

--- a/ui.schema.json
+++ b/ui.schema.json
@@ -5,7 +5,13 @@
     "useHTTPS",
     "database",
     "username",
-    "password"
+    "password",
+    "tls"
   ],
-  "password": { "ui:widget": "password" }
+  "password": { "ui:widget": "password" },
+  "tls": {
+    "ca_cert": { "ui:widget": "file", "ui:emptyValue": null },
+    "cert": { "ui:widget": "file", "ui:emptyValue": null },
+    "key": { "ui:widget": "file", "ui:emptyValue": null }
+  }
 }


### PR DESCRIPTION
Added TLS configuration.

Fixes #386.

According to the [doc](https://clickhouse.com/docs/en/integrations/language-clients/nodejs#tls-certificates), if only `CA Cert` was provided, connection will use `basic` TLS configuration. Otherwise, it requires all three files to be provided to use `mutual` TLS configuration. All fields are optional, but `Cert` requires `CA Cert` and `Key`, and `Key` requires `CA Cert` and `Cert`.

For now there is a problem with empty values. If you write something to field and then clear it you get an error `should match format "data-url"` because it becomes empty string instead of `undefined` or something.

![image](https://github.com/ultram4rine/sqltools-clickhouse-driver/assets/42237599/e504eb01-dbf7-429e-8c59-295a25573827)
